### PR TITLE
Fix/add unique messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,6 @@ server = { workspace = true, optional = true, default-features = false }
 spectator_client = { workspace = true, optional = true, default-features = false }
 rand = "0.9.0"
 
-windows-future = "=0.1.1"
-windows-collections = "=0.1.1"
-
 [features]
 default = ["debug"]
 debug = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["proc_macros", "server", "shared", "spectator_client"]
 
 [package]
 name = "tank-coding-battle"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 
 [workspace.dependencies]

--- a/shared/src/networking/messages/message_container.rs
+++ b/shared/src/networking/messages/message_container.rs
@@ -96,15 +96,19 @@ use super::message_data::{
             /// Can only be sent to itself on the server
             #[target(ToSelf)]
             #[player_state(Alive)]
+            #[unique]
             MoveTankCommand(MoveTankCommand),
             #[target(ToSelf)]
             #[player_state(Alive)]
+            #[unique]
             RotateTankBodyCommand(RotateTankBodyCommand),
             #[target(ToSelf)]
             #[player_state(Alive)]
+            #[unique]
             RotateTankTurretCommand(RotateTankTurretCommand),
             #[target(ToSelf)]
             #[player_state(Alive)]
+            #[unique]
             ShootCommand(ShootCommand),
             GotHit(GotHitMessageData),
             Hit(HitMessageData),


### PR DESCRIPTION
Prevent Cheating by not allowing duplicate messages in a single tick. For example, before you could have sent multiple move commands in a single tick and the server just processed them in order. now we only take the latest one.